### PR TITLE
Remove * text=auto which breaks git line ending checking

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,4 @@
 ###############################################################################
-# Set default behavior to automatically normalize line endings.
-###############################################################################
-* text=auto
-
-###############################################################################
 # Set default behavior for command prompt diff.
 #
 # This is need for earlier builds of msysgit that does not have it on by


### PR DESCRIPTION
The `* text=auto` line makes git behave weirdly by marking files as modified when they are not.

```
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

        modified:   Solutions/Provisioning.OneDrive/Provisioning.OneDrive.sln

no changes added to commit (use "git add" and/or "git commit -a")
```

Checking the file out does not help.

Everything works as expected with the fix in the PR.

`git config --global core.autocrlf input` does not fix it either.

Acceptable fix or user-error?
