### PR TITLE
Bug fix in sandbox solution installation

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/SiteExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/SiteExtensions.cs
@@ -769,7 +769,22 @@ namespace Microsoft.SharePoint.Client
 
             LoggingUtility.Internal.TraceVerbose("Uninstalling package '{0}'", packageInfo.PackageName);
             DesignPackage.UnInstall(site.Context, site, packageInfo);
-            site.Context.ExecuteQuery();
+            try
+            {
+                site.Context.ExecuteQuery();
+            }
+            catch (ServerException ex)
+            {
+                // The execute query fails is the package does not already exist; would be better if we could test beforehand
+                if (ex.Message.StartsWith("Invalid field name. {33e33eca-7712-4f3d-ab83-6848789fc9b6}", StringComparison.OrdinalIgnoreCase))
+                {
+                    LoggingUtility.Internal.TraceVerbose("Package '{0}' does not exist to uninstall, server returned error.", packageInfo.PackageName);
+                }
+                else
+                {
+                    throw;
+                }
+            }
 
             var packageServerRelativeUrl = UrlUtility.Combine(solutionGallery.RootFolder.ServerRelativeUrl, fileName);
             LoggingUtility.Internal.TraceVerbose("Installing package '{0}'", packageInfo.PackageName);


### PR DESCRIPTION
The delete step fails the first time if the package did not previously exist; catch and ignore this specific error.
