### PR TITLE
Switch hardcoded postbuild for powershell to dynamic

### DIFF
--- a/Solutions/PowerShell.Commands/Commands/OfficeDevPnP.PowerShell.Commands.csproj
+++ b/Solutions/PowerShell.Commands/Commands/OfficeDevPnP.PowerShell.Commands.csproj
@@ -227,7 +227,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>"$(SolutionDir)\CmdletHelpGenerator\bin\Debug\OfficeDevPnP.PowerShell.CmdletHelpGenerator.exe"  "$(TargetPath)" "$(TargetDir)\$(TargetFileName)-help.xml"
+    <PostBuildEvent>"$(SolutionDir)\CmdletHelpGenerator\bin\"$(ConfigurationName)\OfficeDevPnP.PowerShell.CmdletHelpGenerator.exe"  "$(TargetPath)" "$(TargetDir)\$(TargetFileName)-help.xml"
 
 "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -file "$(SolutionDir)\PostBuild.ps1" "$(ConfigurationName)" "$(TargetDir)
 </PostBuildEvent>


### PR DESCRIPTION
The post build script had a hardcoded reference to /Debug that broke the script when building for any other config.
