### PR TITLE
Fixed mixup of internal name and staticname

### DIFF
--- a/Solutions/PowerShell.Commands/Commands/Fields/AddField.cs
+++ b/Solutions/PowerShell.Commands/Commands/Fields/AddField.cs
@@ -20,8 +20,8 @@ namespace OfficeDevPnP.PowerShell.Commands
         [Parameter(Mandatory = true, ParameterSetName = "WebPara")]
         public string InternalName;
 
-        [Parameter(Mandatory = false, ParameterSetName = "ListPara")]
-        [Parameter(Mandatory = false, ParameterSetName = "WebPara")]
+        [Parameter(Mandatory = false, ParameterSetName = "ListPara", DontShow = true)]
+        [Parameter(Mandatory = false, ParameterSetName = "WebPara", DontShow = true)]
         public string StaticName;
 
         [Parameter(Mandatory = true, ParameterSetName = "ListPara")]


### PR DESCRIPTION
Fixed logical error on mandatory fields internalname and staticname when creating files. Internalname is now mandatory instead of staticname.
