### PR TITLE
Add read only functionality to taxonomy picker

### DIFF
--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
@@ -216,6 +216,7 @@
         this.Language = (options.language) ? options.language : 'en-us'; //the language code for the control (default is en-us)
         this.MarkerMarkup = '<span id="caretmarker"></span>'; //the marketup const
         this._isMulti = options.isMulti; //specifies if the user can select multiple terms
+        this._isReadOnly = options.isReadOnly; //specifies whether the control is used for display purposes 
         this._allowFillIn = options.allowFillIn; //specifies if the user can add new terms (only applies to Open Termsets)
         this._termSetId = options.termSetId; //the termset id to bind the control to
         this._useHashtags = options.useHashtags; //indicates that the hashtags termset should be used tp bind the control
@@ -275,13 +276,21 @@
             var parent = this._hiddenValidated.parent();
             this._hiddenValidated = this._hiddenValidated.detach();
             parent.append(this._control);
-
-            //add additional controls such as the editor area, suggestions container, dialog button
-            this._editor = $('<div class="cam-taxpicker-editor" contenteditable="true"></div>');
             this._suggestionContainer = $('<div class="cam-taxpicker-suggestion-container"></div>');
             this._dlgButton = $('<div class="cam-taxpicker-button"></div>');
-            this._control.empty().append(this._editor).append(this._dlgButton).append(this._hiddenValidated);
-            this._control.after(this._suggestionContainer);
+            if (!this._isReadOnly) {
+                this._editor = $('<div class="cam-taxpicker-editor" contenteditable="true"></div>');
+                this._control.empty().append(this._editor).append(this._dlgButton).append(this._hiddenValidated);
+                this._control.after(this._suggestionContainer);
+            }
+            else {
+
+                this._editor = $('<div class="cam-taxpicker-editor-readonly" contenteditable="false"></div>');
+                this._control.empty().append(this._editor).append(this._hiddenValidated);
+            }
+
+
+
 
             //initialize value if it exists
             if (this._initialValue != undefined && this._initialValue.length > 0) {
@@ -310,6 +319,8 @@
         },
         //handle keydown event in editor control
         keydown: function (event, args) {
+            // if the control is readonly then ignore all keystrokes
+            if (this._isReadOnly) { return false; }
             //get the keynum
             var keynum = event.which;
 

--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Styles/taxonomypickercontrol.css
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Styles/taxonomypickercontrol.css
@@ -17,6 +17,20 @@
     min-height: 19px;
 }
 
+.cam-taxpicker-editor-readonly {
+    border: 1px solid #99b0c1;
+    cursor: text;
+    color: GrayText; 
+    word-break: break-all;
+    word-wrap: break-word;
+    min-height: 1em;
+    outline: none medium invert;
+    padding: 2px;
+    width: 360px;
+    float: left;
+    min-height: 19px;
+}
+
 .cam-taxpicker-button {
     margin: 2px;
     background: url(images/EMMCopyTerm.png) no-repeat;


### PR DESCRIPTION
I have a client that wanted to use their custom ui in read-only mode if the user did not have write privileges.
