### PR TITLE
Allow the use of Windows Credential Manager instead of hardcoded values

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/App.config.sample
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/App.config.sample
@@ -3,6 +3,12 @@
   <appSettings>
     <add key="SPOTenantUrl" value="https://[tenant]-admin.sharepoint.com" />
     <add key="SPODevSiteUrl" value="https://[tenant].sharepoint.com/sites/dev" />
+    
+    <add key="SPOCredentialManagerLabel" value="[yourlabel]"/>
+    <!-- If the above value is specified, a lookup will be done to the Windows Credential
+    manager for a -Windows- Credential that maps to the label. If not specified, it assumes you want to specify the username 
+    and password in the values below -->
+   
     <add key="SPOUserName" value="user@[tenant].onmicrosoft.com" />
     <add key="SPOPassword" value="" />
   </appSettings>

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/CredentialManager.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/CredentialManager.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OfficeDevPnP.Core.Tests
+{
+    internal static class CredentialManager
+    {
+
+        public static Microsoft.SharePoint.Client.SharePointOnlineCredentials GetCredential(string Name)
+        {
+            Microsoft.SharePoint.Client.SharePointOnlineCredentials credential = null;
+            IntPtr credPtr;
+
+            bool success = CredRead(Name, CRED_TYPE.GENERIC, 0, out credPtr);
+            if (success)
+            {
+                var critCred = new CriticalCredentialHandle(credPtr);
+                var cred = critCred.GetCredential();
+                var username = cred.UserName;
+                var securePassword = new SecureString();
+                string credentialBlob = cred.CredentialBlob;
+                char[] passwordChars = credentialBlob.ToCharArray();
+                foreach (char c in passwordChars)
+                {
+                    securePassword.AppendChar(c);
+                }
+                credential = new Microsoft.SharePoint.Client.SharePointOnlineCredentials(username, securePassword);
+            }
+            return credential;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct NativeCredential
+        {
+            public UInt32 Flags;
+            public CRED_TYPE Type;
+            public IntPtr TargetName;
+            public IntPtr Comment;
+            public System.Runtime.InteropServices.ComTypes.FILETIME LastWritten;
+            public UInt32 CredentialBlobSize;
+            public IntPtr CredentialBlob;
+            public UInt32 Persist;
+            public UInt32 AttributeCount;
+            public IntPtr Attributes;
+            public IntPtr TargetAlias;
+            public IntPtr UserName;
+
+            internal static NativeCredential GetNativeCredential(Credential cred)
+            {
+                NativeCredential ncred = new NativeCredential();
+                ncred.AttributeCount = 0;
+                ncred.Attributes = IntPtr.Zero;
+                ncred.Comment = IntPtr.Zero;
+                ncred.TargetAlias = IntPtr.Zero;
+                ncred.Type = CRED_TYPE.GENERIC;
+                ncred.Persist = (UInt32)1;
+                ncred.CredentialBlobSize = (UInt32)cred.CredentialBlobSize;
+                ncred.TargetName = Marshal.StringToCoTaskMemUni(cred.TargetName);
+                ncred.CredentialBlob = Marshal.StringToCoTaskMemUni(cred.CredentialBlob);
+                ncred.UserName = Marshal.StringToCoTaskMemUni(System.Environment.UserName);
+                return ncred;
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct Credential
+        {
+            public UInt32 Flags;
+            public CRED_TYPE Type;
+            public string TargetName;
+            public string Comment;
+            public System.Runtime.InteropServices.ComTypes.FILETIME LastWritten;
+            public UInt32 CredentialBlobSize;
+            public string CredentialBlob;
+            public UInt32 Persist;
+            public UInt32 AttributeCount;
+            public IntPtr Attributes;
+            public string TargetAlias;
+            public string UserName;
+        }
+
+        public enum CRED_TYPE : uint
+        {
+            GENERIC = 1,
+            DOMAIN_PASSWORD = 2,
+            DOMAIN_CERTIFICATE = 3,
+            DOMAIN_VISIBLE_PASSWORD = 4,
+            GENERIC_CERTIFICATE = 5,
+            DOMAIN_EXTENDED = 6,
+            MAXIMUM = 7,      // Maximum supported cred type
+            MAXIMUM_EX = (MAXIMUM + 1000),  // Allow new applications to run on old OSes
+        }
+
+        public class CriticalCredentialHandle : Microsoft.Win32.SafeHandles.CriticalHandleZeroOrMinusOneIsInvalid
+        {
+            public CriticalCredentialHandle(IntPtr preexistingHandle)
+            {
+                SetHandle(preexistingHandle);
+            }
+
+            public Credential GetCredential()
+            {
+                if (!IsInvalid)
+                {
+                    NativeCredential ncred = (NativeCredential)Marshal.PtrToStructure(handle,
+                          typeof(NativeCredential));
+                    Credential cred = new Credential();
+                    cred.CredentialBlobSize = ncred.CredentialBlobSize;
+                    cred.CredentialBlob = Marshal.PtrToStringUni(ncred.CredentialBlob,
+                          (int)ncred.CredentialBlobSize / 2);
+                    cred.UserName = Marshal.PtrToStringUni(ncred.UserName);
+                    cred.TargetName = Marshal.PtrToStringUni(ncred.TargetName);
+                    cred.TargetAlias = Marshal.PtrToStringUni(ncred.TargetAlias);
+                    cred.Type = ncred.Type;
+                    cred.Flags = ncred.Flags;
+                    cred.Persist = ncred.Persist;
+                    return cred;
+                }
+                else
+                {
+                    throw new InvalidOperationException("Invalid CriticalHandle!");
+                }
+            }
+
+            override protected bool ReleaseHandle()
+            {
+                if (!IsInvalid)
+                {
+                    CredFree(handle);
+                    SetHandleAsInvalid();
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        [DllImport("Advapi32.dll", EntryPoint = "CredReadW", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool CredRead(string target, CRED_TYPE type, int reservedFlag, out IntPtr CredentialPtr);
+
+        [DllImport("Advapi32.dll", EntryPoint = "CredFree", SetLastError = true)]
+        public static extern bool CredFree([In] IntPtr cred);
+    }
+}

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/OfficeDevPnP.Core.Tests.csproj
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/OfficeDevPnP.Core.Tests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="AppModelExtensions\UrlUtilityTests.cs" />
     <Compile Include="AppModelExtensions\WebExtensionsTests.cs" />
     <Compile Include="AppModelExtensions\PageExtensionsTests.cs" />
+    <Compile Include="CredentialManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/TestCommon.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/TestCommon.cs
@@ -7,32 +7,47 @@ using System.Security;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace OfficeDevPnP.Core.Tests {
-    static class TestCommon {
-        static TestCommon() {
+namespace OfficeDevPnP.Core.Tests
+{
+    static class TestCommon
+    {
+        static TestCommon()
+        {
+
+        
             TenantUrl = ConfigurationManager.AppSettings["SPOTenantUrl"];
             DevSiteUrl = ConfigurationManager.AppSettings["SPODevSiteUrl"];
-            UserName = ConfigurationManager.AppSettings["SPOUserName"];
-            var password = ConfigurationManager.AppSettings["SPOPassword"];
 
-            if (string.IsNullOrEmpty(TenantUrl) ||
-                string.IsNullOrEmpty(TenantUrl) ||
-                string.IsNullOrEmpty(TenantUrl) ||
-                string.IsNullOrEmpty(TenantUrl))
+            if (string.IsNullOrEmpty(TenantUrl) || string.IsNullOrEmpty(DevSiteUrl))
+            {
                 throw new ConfigurationErrorsException("Tenant credentials in App.config are not set up.");
+            }
 
-            Password = password.ToSecureString();
 
-            Credentials = new SharePointOnlineCredentials(UserName, Password);
+            if (!string.IsNullOrEmpty(ConfigurationManager.AppSettings["SPOCredentialManagerLabel"]))
+            {
+                Credentials = CredentialManager.GetCredential(ConfigurationManager.AppSettings["SPOCredentialManagerLabel"]);
+            }
+            else
+            {
+                UserName = ConfigurationManager.AppSettings["SPOUserName"];
+                var password = ConfigurationManager.AppSettings["SPOPassword"];
+
+                Password = password.ToSecureString();
+
+                Credentials = new SharePointOnlineCredentials(UserName, Password);
+            }
         }
 
-        public static ClientContext CreateClientContext() {
+        public static ClientContext CreateClientContext()
+        {
             var clientContext = new ClientContext(DevSiteUrl);
             clientContext.Credentials = Credentials;
             return clientContext;
         }
 
-        public static ClientContext CreateTenantClientContext() {
+        public static ClientContext CreateTenantClientContext()
+        {
             var clientContext = new ClientContext(TenantUrl);
             clientContext.Credentials = Credentials;
             return clientContext;
@@ -43,5 +58,7 @@ namespace OfficeDevPnP.Core.Tests {
         static string UserName { get; set; }
         static SecureString Password { get; set; }
         static System.Net.ICredentials Credentials { get; set; }
+
+
     }
 }


### PR DESCRIPTION
This allows the use of a Credential Manager entry instead of specifying the username and password in the appconfig for the test project in core. It's enough to specify the SPOCredentialManagerLabel entry in the app.config with an label of an entry in the Windows Credential manager to pick up that value. This would prevent accidentally committing usernames and passwords.

Fixed a wrong check in TestCommon too (it was checking 4 times for the existence of the tenanturl)
