### PR TITLE
Added an AddFolder commandlet to create sub folders

### DIFF
--- a/Solutions/PowerShell.Commands/Commands/OfficeDevPnP.PowerShell.Commands.csproj
+++ b/Solutions/PowerShell.Commands/Commands/OfficeDevPnP.PowerShell.Commands.csproj
@@ -188,6 +188,7 @@
     <Compile Include="Lists\RemoveView.cs" />
     <Compile Include="Lists\RemoveList.cs" />
     <Compile Include="Base\PipeBinds\ViewPipeBind.cs" />
+    <Compile Include="Web\AddFolder.cs" />
     <Compile Include="Workflows\ResumeWorkflowInstance.cs" />
     <Compile Include="Workflows\StopWorkflowInstance.cs" />
     <Compile Include="Workflows\RemoveWorkflowDefinition.cs" />

--- a/Solutions/PowerShell.Commands/Commands/Web/AddFolder.cs
+++ b/Solutions/PowerShell.Commands/Commands/Web/AddFolder.cs
@@ -1,0 +1,36 @@
+﻿using OfficeDevPnP.PowerShell.CmdletHelpAttributes;
+using OfficeDevPnP.PowerShell.Commands.Base;
+using Microsoft.SharePoint.Client;
+using System.Management.Automation;
+using System;
+
+namespace OfficeDevPnP.PowerShell.Commands
+{
+    [Cmdlet(VerbsCommon.Add, "SPOFolder")]
+    [CmdletHelp("Creates a folder within a parent folder")]
+    [CmdletExample(Code = @"
+PS:> Add-SPOFolder -Name NewFolder -Folder _catalogs/masterpage/newfolder")]
+    public class AddFolder : SPOWebCmdlet
+    {
+        [Parameter(Mandatory = true, HelpMessage = "The folder name")]
+        public string Name = string.Empty;
+
+        [Parameter(Mandatory = true, HelpMessage = "The parent folder in the site")]
+        public string Folder = string.Empty;
+
+        protected override void ExecuteCmdlet()
+        {
+            if (!this.SelectedWeb.IsPropertyAvailable("ServerRelativeUrl"))
+            {
+                ClientContext.Load(this.SelectedWeb, w => w.ServerRelativeUrl);
+                ClientContext.ExecuteQuery();
+            }
+
+            Folder folder = this.SelectedWeb.GetFolderByServerRelativeUrl(UrlUtility.Combine(this.SelectedWeb.ServerRelativeUrl, Folder));
+            ClientContext.Load(folder, f => f.ServerRelativeUrl);
+            ClientContext.ExecuteQuery();
+
+            folder.CreateFolder(Name);
+        }
+    }
+}


### PR DESCRIPTION
I've written a powershell script to bulk upload files to SharePoint but Add-SPOFile doesn't automatically create the folder if it doesn't exist, so I wrote Add-SPOFolder to take care of this.

Here's the PowerShell where I use these two together for reference.

$path = "$dir\Main\Files"
$excludeList = @()
Get-ChildItem -Path $path -Recurse | % {
    $pathParts = $_.FullName.substring($pwd.path.Length + 1).split("\");
    if ( ! ($excludeList | where { $pathParts -like $_ } ) ) { 
        $folder = $_.FullName.Replace($path+"\", "").Replace("\"+$_.Name, "").Replace("\", "/")  
        if ($_.GetType().Name -eq "DirectoryInfo") {
            Add-SPOFolder -Name $_.Name -Folder $folder
        }
        if ($_.GetType().Name -eq "FileInfo") {  
            Add-SPOFile -Path $_.FullName -Folder $folder
        }
    } 
}
