### PR TITLE
Update CSVWriter.cs

### DIFF
--- a/Samples/Core.BulkUserProfileUpdater/Utilities/CSVWriter.cs
+++ b/Samples/Core.BulkUserProfileUpdater/Utilities/CSVWriter.cs
@@ -59,7 +59,11 @@ namespace Contoso.Core.Utilities
                 }
 
                 userdata.CellEntry = entry.ToString();
-
+                
+                //Replaces a line break ("\r\n") with a single space.  Line breaks are typically encountered in the streetAddress field in Active Directory.
+                if (userdata.CellEntry.Contains("\r\n"))
+                    userdata.CellEntry = userdata.CellEntry.Replace("\r\n", " ");
+                
                 // Output string to CSV file
                 WriteLine(userdata.CellEntry);
 


### PR DESCRIPTION
I found that when the "streetAddress" field in AD is split into multiple lines, the line break is fed into the string as "\r\n" and parsed into a new "user" entry in the CSV file.  This update replaces the "\r\n" with a single space to prevent this issue.
