### PR TITLE
Update BrandingExtensions.cs

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
@@ -968,6 +968,9 @@ namespace Microsoft.SharePoint.Client
                 throw new ArgumentNullException("pageLayoutName");
 
             var masterPageGallery = web.GetCatalog((int)ListTemplateType.MasterPageCatalog);
+            web.Context.Load(masterPageGallery, x => x.RootFolder.ServerRelativeUrl);
+            web.Context.ExecuteQuery();
+            
             var fileRefValue = string.Format("{0}/{1}{2}", masterPageGallery.RootFolder.ServerRelativeUrl, pageLayoutName,
                 ".aspx");
             var query = new CamlQuery();


### PR DESCRIPTION
ServerRelativeUrl not initialized in BrandingExtensions/GetPageLayoutListItemByName

Added missing Context.Load for ServerRelativeUrl on MasterPage gallery.
Fails when called from CreateXmlNodeFromPageLayout.

Link to #280  
