### PR TITLE
Removed not supported cmdlets when using V15 SDK

### DIFF
--- a/Solutions/PowerShell.Commands/Commands/Admin/GetWebTemplates.cs
+++ b/Solutions/PowerShell.Commands/Commands/Admin/GetWebTemplates.cs
@@ -1,4 +1,5 @@
-﻿using OfficeDevPnP.PowerShell.CmdletHelpAttributes;
+﻿#if !CLIENTSDKV15
+using OfficeDevPnP.PowerShell.CmdletHelpAttributes;
 using Microsoft.SharePoint.Client;
 using OfficeDevPnP.PowerShell.Commands.Base;
 using System.Management.Automation;
@@ -30,3 +31,4 @@ You must connect to the admin website (https://:<tenant>-admin.sharepoint.com) w
         }
     }
 }
+#endif

--- a/Solutions/PowerShell.Commands/Commands/Admin/NewTenantSite.cs
+++ b/Solutions/PowerShell.Commands/Commands/Admin/NewTenantSite.cs
@@ -1,4 +1,5 @@
-﻿using OfficeDevPnP.PowerShell.CmdletHelpAttributes;
+﻿#if !CLIENTSDKV15
+using OfficeDevPnP.PowerShell.CmdletHelpAttributes;
 using OfficeDevPnP.PowerShell.Commands.Base;
 using Microsoft.SharePoint.Client;
 using System;
@@ -73,3 +74,4 @@ available quota.
 
     }
 }
+#endif

--- a/Solutions/PowerShell.Commands/Commands/Admin/RemoveTenantSite.cs
+++ b/Solutions/PowerShell.Commands/Commands/Admin/RemoveTenantSite.cs
@@ -1,4 +1,5 @@
-﻿using OfficeDevPnP.PowerShell.CmdletHelpAttributes;
+﻿#if !CLIENTSDKV15
+using OfficeDevPnP.PowerShell.CmdletHelpAttributes;
 using OfficeDevPnP.PowerShell.Commands.Base;
 using Microsoft.Online.SharePoint.TenantAdministration;
 using Microsoft.SharePoint.Client;
@@ -47,3 +48,4 @@ You must connect to the admin website (https://:<tenant>-admin.sharepoint.com) w
 
     }
 }
+#endif

--- a/Solutions/PowerShell.Commands/Commands/Admin/SetTenantSite.cs
+++ b/Solutions/PowerShell.Commands/Commands/Admin/SetTenantSite.cs
@@ -1,4 +1,5 @@
-﻿using OfficeDevPnP.PowerShell.CmdletHelpAttributes;
+﻿#if !CLIENTSDKV15
+using OfficeDevPnP.PowerShell.CmdletHelpAttributes;
 using OfficeDevPnP.PowerShell.Commands.Base;
 using System.Management.Automation;
 using Microsoft.SharePoint.Client;
@@ -44,5 +45,4 @@ You must connect to the admin website (https://:<tenant>-admin.sharepoint.com) w
     }
 
 }
-
-
+#endif


### PR DESCRIPTION
Removed Get-SPOWebTemplates, New-SPOTenantSite, Remove-SPOTenantSite, Set-SPOTenantSite cmdlets when compiling against the V15 SDK as they are not supported on-premises.
