### PR TITLE
Small cmdlet updates

### DIFF
--- a/Solutions/PowerShell.Commands/Commands/Web/NewWeb.cs
+++ b/Solutions/PowerShell.Commands/Commands/Web/NewWeb.cs
@@ -34,8 +34,10 @@ PS:> New-SPOWeb -Title ""Project A Web"" -Url projectA -Description ""Informatio
         public SwitchParameter InheritNavigation = true;
         protected override void ExecuteCmdlet()
         {
-            this.SelectedWeb.CreateWeb(Title, Url, Description, Template, Locale, !BreakInheritance,InheritNavigation);
-            WriteVerbose(string.Format(Properties.Resources.Web0CreatedAt1, Title, Url));
+            var web = this.SelectedWeb.CreateWeb(Title, Url, Description, Template, Locale, !BreakInheritance,InheritNavigation);
+            ClientContext.Load(web, w => w.Id, w => w.Url);
+            ClientContext.ExecuteQuery();
+            WriteObject(web);
         }
 
     }

--- a/Solutions/PowerShell.Commands/changelog.md
+++ b/Solutions/PowerShell.Commands/changelog.md
@@ -1,5 +1,10 @@
 # OfficeDevPnP.PowerShell Changelog #
 
+**2014-12-30**
+* Changed New-SPOWeb to return the actual web as an object instead of a success message.
+* Added -SetAssociatedGroup parameter to New-SPOGroup to set a group as a default associated visitors, members or owners group
+* Updated New-SPOGroup to allow setting groups as owners
+
 **2014-12-01**
 * Added Get-SPOListItem cmdlet to retrieve list items by id, unique id, or CAML. Optionally you can define which fields to load.
 **2014-11-05**


### PR DESCRIPTION
- Changed new-spogroup to allow to set a group as the owner, optionally setting the same group as the group you're creating as the owner.
- Added a parameter to new-spogroup to set the default as a default associated group (visitors, members or owners)
- Made new-spoweb return the actual web object instead of a success message.
