### PR TITLE
Script bundling support for Taxonomy Picker resources js file (#1593)

### DIFF
--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
@@ -359,16 +359,13 @@
             });
 
             //load translation files
-            if (typeof CAMControl.resourceLoaded == 'undefined') {
-                CAMControl.resourceLoaded = false;
+            if (!window.TaxonomyPickerConsts) {
                 var resourceFileName = scriptUrl + '_resources.' + this.Language.substring(0, 2).toLowerCase() + '.js';
 
                 jQuery.ajax({
                     dataType: "script",
                     cache: true,
                     url: resourceFileName
-                }).done(function () {
-                    CAMControl.resourceLoaded = true;
                 }).fail(function () {
                     alert('Could not load the resource file ' + resourceFileName);
                 });

--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol_resources.en.js
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol_resources.en.js
@@ -1,9 +1,10 @@
-﻿function TaxonomyPickerConsts() { };
-TaxonomyPickerConsts.SUGGESTIONS_HEADER = 'Suggestions';
-TaxonomyPickerConsts.DIALOG_HEADER = 'Select: ';
-TaxonomyPickerConsts.BUTTON_TEXT = 'Select';
-TaxonomyPickerConsts.AMBIGUOUS_ENTRY = 'Ambiguous Entry';
-TaxonomyPickerConsts.DIALOG_ADD_TITLE = 'New items are added under the currently selected item.';
-TaxonomyPickerConsts.DIALOG_ADD_LINK = 'Add New Item';
-TaxonomyPickerConsts.TERMSET_LOAD_FAILED = 'Loading TermSet failed.  Please refresh your browser and try again.';
-TaxonomyPickerConsts.WORKING_ON_IT = '&nbsp;Working on it...';
+﻿window.TaxonomyPickerConsts = {
+    SUGGESTIONS_HEADER: 'Suggestions',
+    DIALOG_HEADER: 'Select: ',
+    BUTTON_TEXT: 'Select',
+    AMBIGUOUS_ENTRY: 'Ambiguous Entry',
+    DIALOG_ADD_TITLE: 'New items are added under the currently selected item.',
+    DIALOG_ADD_LINK: 'Add New Item',
+    TERMSET_LOAD_FAILED: 'Loading TermSet failed.  Please refresh your browser and try again.',
+    WORKING_ON_IT: '&nbsp;Working on it...'
+};


### PR DESCRIPTION
Before loading the '....resources.en.js' file via jQuery ajax in the taxonomy picker, the global namespace is checked first. If the resources have already been loaded then they are not re-loaded. This allows pre-loading via a script bundling mechanism. If the resources are not present, then the old ajax loading mechanism is maintained.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixed #1593 