### PR TITLE
Support for loading default value by label only

### DIFF
--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
@@ -396,11 +396,19 @@
                 this._control.empty().append(this._editor).append(this._hiddenValidated);
             }
 
-
-
-
             //initialize value if it exists
-            if (this._initialValue != undefined && this._initialValue.length > 0) {
+            if (this._initialLabels) {
+                //When the termset is loaded, terms with the supplied labels are initially selected
+                this.TermSet.OnTermsLoaded = Function.createDelegate(this, function () {
+                    for (var j = 0; j < this._initialLabels.length; j++) {
+                        var terms = this.TermSet.getTermsByLabel(this._initialLabels[j]);
+                        for (var i = 0; i < terms.length; i++) {
+                            this.pushSelectedTerm(terms[i]);
+                        }
+                    }
+                    this._editor.html(this.selectedTermsToHtml());
+                });
+            } else if (this._initialValue != undefined && this._initialValue.length > 0) {
                 var terms = JSON.parse(this._initialValue);
                 for (var i = 0; i < terms.length; i++) {
                     //add the term to selected terms array


### PR DESCRIPTION
Added new option 'initialLabels' which allows you to specify an array of term labels which will be initially selected once the termset loads. This is an alternative to the existing value on the HTML input control which must be JSON and must contain the IDs of the terms to be pre-selected. In some cases, the IDs are not known.

| Q               | A
| --------------- | ---
| Bug fix?        | no 
| New feature?    | yes
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?

Support for new 'initialLabels' option.