### PR TITLE
Fix bug when filterTerm == undefined due to .Name being used

### DIFF
--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
@@ -150,10 +150,10 @@
                         if (term.Level == currentLevel) {
                             var path = term.PathOfTerm.split(';');
                             if (
+							    typeof (filterTerm) == 'undefined' ||
                                 ((path.length == this.LevelToShowTerms && this.FilterTermId != null && this.FilterTermId == term.Id) ||
-                                (this.FilterTermId != null && term.PathOfTerm.indexOf(filterTerm.Name) > -1 && this.LevelToShowTerms - 1 == term.Level)
-
-                                ) || typeof (filterTerm) == 'undefined') {
+                                (this.FilterTermId != null && term.PathOfTerm.indexOf(filterTerm.Name) > -1 && this.LevelToShowTerms - 1 == term.Level))
+								) {
 
                                 if (currentLevel == 0) {
                                     this.Terms.push(term.clone());


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | none

#### What's in this Pull Request?

Fixed a small issue which is caused by filterTerm being undefined. There's a check on undefined, but before that can take place, the first part of the if-statement uses filterTerm.Name which will fail when it's undefined. By switching the two sides of the OR statement, this is fixed; it will not execute the second part when the first part already evaluates to true. 