### PR TITLE
RemoteCalendarAccess: Fixed casing of WKST value in RRULES

### DIFF
--- a/Samples/BusinessApps.RemoteCalendarAccess/BusinessApps.RemoteCalendarAccessWeb/Models/CalendarModel/RecurrenceHelper.cs
+++ b/Samples/BusinessApps.RemoteCalendarAccess/BusinessApps.RemoteCalendarAccessWeb/Models/CalendarModel/RecurrenceHelper.cs
@@ -53,7 +53,7 @@ namespace BusinessApps.RemoteCalendarAccess.Models.CalendarModel
 
         private void AppendWeekly(StringBuilder builder, dynamic weekly, dynamic json)
         {
-            builder.Append("WEEKLY;INTERVAL=" + weekly.weekFrequency + ";WKST=" + json.recurrence.rule.firstDayOfWeek);
+            builder.Append("WEEKLY;INTERVAL=" + weekly.weekFrequency + ";WKST=" + ((string)json.recurrence.rule.firstDayOfWeek).ToUpperInvariant());
 
             if (weekly.su == "TRUE" || weekly.mo == "TRUE" || weekly.tu == "TRUE" || weekly.we == "TRUE" ||
                 weekly.th == "TRUE" || weekly.fr == "TRUE" || weekly.sa == "TRUE")


### PR DESCRIPTION
This is a bug fix for the RemoteCalendarAccess project. It turns the WKST (day on which the workweek starts) value in Recurrence Rules to uppercase characters. Uppercase letters are required here as per: http://www.kanzaki.com/docs/ical/recur.html and https://icalendar.org/iCalendar-RFC-5545/3-3-10-recurrence-rule.html
