### PR TITLE
Optimization of large file upload in SharePoint by removing unnecessary memory allocation on the last chunk

### DIFF
--- a/Samples/Core.LargeFileUpload/Core.LargeFileUpload/FileUploadService.cs
+++ b/Samples/Core.LargeFileUpload/Core.LargeFileUpload/FileUploadService.cs
@@ -85,26 +85,15 @@ namespace Contoso.Core.LargeFileUpload
                     using (BinaryReader br = new BinaryReader(fs))
                     {
                         byte[] buffer = new byte[blockSize];
-                        Byte[] lastBuffer = null;
                         long fileoffset = 0;
                         long totalBytesRead = 0;
                         int bytesRead;
                         bool first = true;
-                        bool last = false;
 
                         // Read data from filesystem in blocks 
                         while ((bytesRead = br.Read(buffer, 0, buffer.Length)) > 0)
                         {
                             totalBytesRead = totalBytesRead + bytesRead;
-
-                            // We've reached the end of the file
-                            if (totalBytesRead == fileSize)
-                            {
-                                last = true;
-                                // Copy to a new buffer that has the correct size
-                                lastBuffer = new byte[bytesRead];
-                                Array.Copy(buffer, 0, lastBuffer, 0, bytesRead);
-                            }
 
                             if (first)
                             {
@@ -136,10 +125,10 @@ namespace Contoso.Core.LargeFileUpload
                                 // Get a reference to our file
                                 uploadFile = ctx.Web.GetFileByServerRelativeUrl(docs.RootFolder.ServerRelativeUrl + System.IO.Path.AltDirectorySeparatorChar + uniqueFileName);
 
-                                if (last)
+                                if (totalBytesRead == fileSize)
                                 {
-                                    // Is this the last slice of data?
-                                    using (MemoryStream s = new MemoryStream(lastBuffer))
+                                    // We've reached the end of the file
+                                    using (MemoryStream s = new MemoryStream(buffer, 0, bytesRead))
                                     {
                                         // End sliced upload by calling FinishUpload
                                         uploadFile = uploadFile.FinishUpload(uploadId, fileoffset, s);

--- a/Samples/Core.LargeFileUpload/README.md
+++ b/Samples/Core.LargeFileUpload/README.md
@@ -147,26 +147,15 @@ try
     using (BinaryReader br = new BinaryReader(fs))
     {
         byte[] buffer = new byte[blockSize];
-        Byte[] lastBuffer = null;
         long fileoffset = 0;
         long totalBytesRead = 0;
         int bytesRead;
         bool first = true;
-        bool last = false;
 
         // Read data from filesystem in blocks 
         while ((bytesRead = br.Read(buffer, 0, buffer.Length)) > 0)
         {
             totalBytesRead = totalBytesRead + bytesRead;
-
-            // We've reached the end of the file
-            if (totalBytesRead == fileSize)
-            {
-                last = true;
-                // Copy to a new buffer that has the correct size
-                lastBuffer = new byte[bytesRead];
-                Array.Copy(buffer, 0, lastBuffer, 0, bytesRead);
-            }
 
             if (first)
             {
@@ -197,11 +186,11 @@ try
             {
                 // Get a reference to our file
                 uploadFile = ctx.Web.GetFileByServerRelativeUrl(docs.RootFolder.ServerRelativeUrl + System.IO.Path.AltDirectorySeparatorChar + uniqueFileName);
-
-                if (last)
+                
+                if (totalBytesRead == fileSize)
                 {
-                    // Is this the last slice of data?
-                    using (MemoryStream s = new MemoryStream(lastBuffer))
+                    // We've reached the end of the file
+                    using (MemoryStream s = new MemoryStream(buffer, 0, bytesRead))
                     {
                         // End sliced upload by calling FinishUpload
                         uploadFile = uploadFile.FinishUpload(uploadId, fileoffset, s);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  |

#### What's in this Pull Request?

Optimization of the large file upload method in SharePoint by removing an unnecessary memory allocation on the last chunk